### PR TITLE
Add AXResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 coverage/*
 doc/*
 benchmarks/*
+.idea/*

--- a/lib/authlogic_openid/acts_as_authentic.rb
+++ b/lib/authlogic_openid/acts_as_authentic.rb
@@ -107,10 +107,8 @@ module AuthlogicOpenid
           return false
         end
 
-      # Find an existing record. By default, maps users based on openid_identifier. Override this method to match
-      # users based on different criteria, for example email address
       def self.find_existing_openid_registration(openid_identifier, sreg_response, ax_response)
-          find_by_openid_identifier_method(openid_identifier)
+          find_by_openid_identifier(openid_identifier)
       end
 
         # Override this method to map the OpenID registration fields with fields in your model. See the required_fields and

--- a/lib/authlogic_openid/acts_as_authentic.rb
+++ b/lib/authlogic_openid/acts_as_authentic.rb
@@ -12,7 +12,7 @@ module AuthlogicOpenid
         add_acts_as_authentic_module(Methods, :prepend)
       end
     end
-    
+
     module Config
       # Some OpenID providers support a lightweight profile exchange protocol, for those that do, you can require
       # certain fields. This is convenient for new registrations, as it will basically fill out the fields in the
@@ -26,7 +26,7 @@ module AuthlogicOpenid
         rw_config(:openid_required_fields, value, [])
       end
       alias_method :openid_required_fields=, :openid_required_fields
-      
+
       # Same as required_fields, but optional instead.
       #
       # * <tt>Default:</tt> []
@@ -36,12 +36,12 @@ module AuthlogicOpenid
       end
       alias_method :openid_optional_fields=, :openid_optional_fields
     end
-    
+
     module Methods
       # Set up some simple validations
       def self.included(klass)
         return if !klass.column_names.include?("openid_identifier")
-        
+
         klass.class_eval do
           validates_uniqueness_of :openid_identifier, :scope => validations_scope, :if => :using_openid?
           validate :validate_openid
@@ -50,7 +50,7 @@ module AuthlogicOpenid
           validates_length_of_password_confirmation_field_options validates_length_of_password_confirmation_field_options.merge(:if => :validate_password_with_openid?)
         end
       end
-      
+
       # Set the openid_identifier field and also resets the persistence_token if this value changes.
       def openid_identifier=(value)
         write_attribute(:openid_identifier, value.blank? ? nil : OpenID.normalize_url(value))
@@ -58,7 +58,7 @@ module AuthlogicOpenid
       rescue OpenID::DiscoveryFailure => e
         @openid_error = e.message
       end
-      
+
       # This is where all of the magic happens. This is where we hook in and add all of the OpenID sweetness.
       #
       # I had to take this approach because when authenticating with OpenID nonces and what not are stored in database
@@ -75,11 +75,11 @@ module AuthlogicOpenid
         yield(result) if block_given?
         result
       end
-      
+
       private
         def authenticate_with_openid
           @openid_error = nil
-          
+
           if !openid_complete?
             session_class.controller.session[:openid_attributes] = attributes_to_save
           else
@@ -92,7 +92,7 @@ module AuthlogicOpenid
            :optional => self.class.openid_optional_fields,
            :return_to => session_class.controller.url_for(:for_model => "1"),
            :method => :post }
-          
+
           session_class.controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, sreg_response, ax_response|
             if result.unsuccessful?
               @openid_error = result.message
@@ -100,13 +100,19 @@ module AuthlogicOpenid
               self.openid_identifier = openid_identifier
               map_openid_registration(sreg_response, ax_response)
             end
-            
+
             return true
           end
-          
+
           return false
         end
-        
+
+      # Find an existing record. By default, maps users based on openid_identifier. Override this method to match
+      # users based on different criteria, for example email address
+      def self.find_existing_openid_registration(openid_identifier, sreg_response, ax_response)
+          find_by_openid_identifier_method(openid_identifier)
+      end
+
         # Override this method to map the OpenID registration fields with fields in your model. See the required_fields and
         # optional_fields configuration options to enable this feature.
         #
@@ -117,7 +123,7 @@ module AuthlogicOpenid
           self.first_name ||= sreg_response[:fullname].split(" ").first if respond_to?(:first_name) && !sreg_response[:fullname].blank?
           self.last_name ||= sreg_response[:fullname].split(" ").last if respond_to?(:last_name) && !sreg_response[:last_name].blank?
         end
-        
+
         # This method works in conjunction with map_saved_attributes.
         #
         # Let's say a user fills out a registration form, provides an OpenID and submits the form. They are then redirected to their
@@ -127,13 +133,13 @@ module AuthlogicOpenid
         # more just override this method and do whatever you want.
         def attributes_to_save # :doc:
           attrs_to_save = attributes.clone.delete_if do |k, v|
-            [:id, :password, crypted_password_field, password_salt_field, :persistence_token, :perishable_token, :single_access_token, :login_count, 
+            [:id, :password, crypted_password_field, password_salt_field, :persistence_token, :perishable_token, :single_access_token, :login_count,
               :failed_login_count, :last_request_at, :current_login_at, :last_login_at, :current_login_ip, :last_login_ip, :created_at,
               :updated_at, :lock_version].include?(k.to_sym)
           end
           attrs_to_save.merge!(:password => password, :password_confirmation => password_confirmation)
         end
-        
+
         # This method works in conjunction with attributes_to_save. See that method for a description of the why these methods exist.
         #
         # If the default behavior of this method is not sufficient for you because you have attr_protected or attr_accessible then
@@ -145,23 +151,23 @@ module AuthlogicOpenid
         def map_saved_attributes(attrs) # :doc:
           self.attributes = attrs
         end
-        
+
         def validate_openid
           errors.add(:openid_identifier, "had the following error: #{@openid_error}") if @openid_error
         end
-        
+
         def using_openid?
           respond_to?(:openid_identifier) && !openid_identifier.blank?
         end
-        
+
         def openid_complete?
           session_class.controller.using_open_id? && session_class.controller.params[:for_model]
         end
-        
+
         def authenticate_with_openid?
           session_class.activated? && ((using_openid? && openid_identifier_changed?) || openid_complete?)
         end
-        
+
         def validate_password_with_openid?
           !using_openid? && require_password?
         end

--- a/lib/authlogic_openid/acts_as_authentic.rb
+++ b/lib/authlogic_openid/acts_as_authentic.rb
@@ -76,6 +76,10 @@ module AuthlogicOpenid
         result
       end
 
+      def self.find_existing_openid_registration(openid_identifier, sreg_response, ax_response)
+          find_by_openid_identifier(openid_identifier)
+      end
+
       private
         def authenticate_with_openid
           @openid_error = nil
@@ -106,10 +110,6 @@ module AuthlogicOpenid
 
           return false
         end
-
-      def self.find_existing_openid_registration(openid_identifier, sreg_response, ax_response)
-          find_by_openid_identifier(openid_identifier)
-      end
 
         # Override this method to map the OpenID registration fields with fields in your model. See the required_fields and
         # optional_fields configuration options to enable this feature.

--- a/lib/authlogic_openid/acts_as_authentic.rb
+++ b/lib/authlogic_openid/acts_as_authentic.rb
@@ -93,12 +93,12 @@ module AuthlogicOpenid
            :return_to => session_class.controller.url_for(:for_model => "1"),
            :method => :post }
           
-          session_class.controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, registration|
+          session_class.controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, sreg_response, ax_response|
             if result.unsuccessful?
               @openid_error = result.message
             else
               self.openid_identifier = openid_identifier
-              map_openid_registration(registration)
+              map_openid_registration(sreg_response, ax_response)
             end
             
             return true
@@ -112,10 +112,10 @@ module AuthlogicOpenid
         #
         # Basically you will get a hash of values passed as a single argument. Then just map them as you see fit. Check out
         # the source of this method for an example.
-        def map_openid_registration(registration) # :doc:
-          self.name ||= registration[:fullname] if respond_to?(:name) && !registration[:fullname].blank?
-          self.first_name ||= registration[:fullname].split(" ").first if respond_to?(:first_name) && !registration[:fullname].blank?
-          self.last_name ||= registration[:fullname].split(" ").last if respond_to?(:last_name) && !registration[:last_name].blank?
+        def map_openid_registration(sreg_response, ax_response) # :doc:
+          self.name ||= sreg_response[:fullname] if respond_to?(:name) && !sreg_response[:fullname].blank?
+          self.first_name ||= sreg_response[:fullname].split(" ").first if respond_to?(:first_name) && !sreg_response[:fullname].blank?
+          self.last_name ||= sreg_response[:fullname].split(" ").last if respond_to?(:last_name) && !sreg_response[:last_name].blank?
         end
         
         # This method works in conjunction with map_saved_attributes.

--- a/lib/authlogic_openid/session.rb
+++ b/lib/authlogic_openid/session.rb
@@ -66,7 +66,7 @@ module AuthlogicOpenid
         @openid_error = e.message
       end
       
-      # Cleaers out the block if we are authenticating with OpenID, so that we can redirect without a DoubleRender
+      # Clears out the block if we are authenticating with OpenID, so that we can redirect without a DoubleRender
       # error.
       def save(&block)
         block = nil if !openid_identifier.blank? && controller.request.env[Rack::OpenID::RESPONSE].blank?
@@ -101,7 +101,7 @@ module AuthlogicOpenid
               return
             end
             
-            self.attempted_record = klass.send(find_by_openid_identifier_method, openid_identifier)
+            self.attempted_record = klass.send(find_existing_openid_registration, openid_identifier, sreg_response, ax_response)
             
             if !attempted_record
               if auto_register?

--- a/lib/authlogic_openid/session.rb
+++ b/lib/authlogic_openid/session.rb
@@ -24,10 +24,13 @@ module AuthlogicOpenid
       #
       # * <tt>Default:</tt> :find_by_openid_identifier
       # * <tt>Accepts:</tt> Symbol
-      def find_by_openid_identifier_method(value = nil)
-        rw_config(:find_by_openid_identifier_method, value, :find_by_openid_identifier)
+      def find_existing_openid_registration_method(value = nil)
+#        rw_config(:find_by_openid_identifier_method, value, :find_by_openid_identifier)
+        rw_config(:find_existing_openid_registration_method, value, :find_existing_openid_registration)
       end
-      alias_method :find_by_openid_identifier_method=, :find_by_openid_identifier_method
+#      alias_method :find_by_openid_identifier_method=, :find_by_openid_identifier_method
+      alias_method :find_existing_openid_registration_method=, :find_existing_openid_registration_method
+
 
       # Add this in your Session object to Auto Register a new user using openid via sreg
       def auto_register(value=true)
@@ -78,8 +81,8 @@ module AuthlogicOpenid
           attempted_record.nil? && errors.empty? && (!openid_identifier.blank? || (controller.using_open_id? && controller.params[:for_session]))
         end
         
-        def find_by_openid_identifier_method
-          self.class.find_by_openid_identifier_method
+        def find_existing_openid_registration_method
+          self.class.find_existing_openid_registration_method
         end
 
         def auto_register?
@@ -101,7 +104,7 @@ module AuthlogicOpenid
               return
             end
             
-            self.attempted_record = klass.send(find_existing_openid_registration, openid_identifier, sreg_response, ax_response)
+            self.attempted_record = klass.send(find_existing_openid_registration_method, openid_identifier, sreg_response, ax_response)
             
             if !attempted_record
               if auto_register?

--- a/lib/authlogic_openid/session.rb
+++ b/lib/authlogic_openid/session.rb
@@ -115,6 +115,11 @@ module AuthlogicOpenid
             else
               errors.add(:openid_identifier, "did not match any users in our database, have you set up your account to use OpenID?")
             end
+          elsif attempted_record.openid_identifier != openid_identifier
+            #update openid_identifier for an existing record
+            attempted_record.openid_identifier = openid_identifier
+            # should we call map_openid_registration again? I don't think so..
+            attempted_record.save_without_session_maintenance
           end
         end
       end

--- a/lib/authlogic_openid/session.rb
+++ b/lib/authlogic_openid/session.rb
@@ -82,10 +82,6 @@ module AuthlogicOpenid
           self.class.find_by_openid_identifier_method
         end
 
-        def find_by_openid_identifier_method
-          self.class.find_by_openid_identifier_method
-        end
-
         def auto_register?
           self.class.auto_register_value
         end
@@ -99,7 +95,7 @@ module AuthlogicOpenid
            :return_to => controller.url_for(:for_session => "1", :remember_me => remember_me?),
            :method => :post}
 
-          controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, registration|
+          controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, sreg_response, ax_response|
             if result.unsuccessful?
               errors.add_to_base(result.message)
               return
@@ -109,7 +105,7 @@ module AuthlogicOpenid
             
             if !attempted_record
               if auto_register?
-                auto_reg_record = create_open_id_auto_register_record(openid_identifier, registration)
+                auto_reg_record = create_open_id_auto_register_record(openid_identifier, sreg_response, ax_response)
                 if !auto_reg_record.save_without_session_maintenance
                   auto_reg_record.errors.each {|attr, msg| errors.add(attr, msg) }
                 else
@@ -122,10 +118,10 @@ module AuthlogicOpenid
           end
         end
 
-        def create_open_id_auto_register_record(openid_identifier, registration)
+        def create_open_id_auto_register_record(openid_identifier, sreg_response, ax_response)
           returning klass.new do |auto_reg_record|
             auto_reg_record.openid_identifier = openid_identifier
-            auto_reg_record.send(:map_openid_registration, registration)
+            auto_reg_record.send(:map_openid_registration, sreg_response, ax_response)
           end
         end
         

--- a/lib/authlogic_openid/session.rb
+++ b/lib/authlogic_openid/session.rb
@@ -8,29 +8,27 @@ module AuthlogicOpenid
         include Methods
       end
     end
-    
+
     module Config
-      # What method should we call to find a record by the openid_identifier?
+      # What method should we call to find an existing openid record?
       # This is useful if you want to store multiple openid_identifiers for a single record.
       # You could do something like:
       #
       #   class User < ActiveRecord::Base
-      #     def self.find_by_openid_identifier(identifier)
-      #       user.first(:conditions => {:openid_identifiers => {:identifier => identifier}})
+      #     def self.find_existing_openid_registration(openid_identifier, sreg_response, ax_response)
+      #       user.first(:conditions => {:openid_identifiers => {:identifier => openid_identifier}})
       #     end
       #   end
       #
-      # Obviously the above depends on what you are calling your assocition, etc. But you get the point.
+      # Obviously the above depends on what you are calling your association, etc. But you get the point.
       #
-      # * <tt>Default:</tt> :find_by_openid_identifier
+      # * <tt>Default:</tt> :find_existing_openid_registration
       # * <tt>Accepts:</tt> Symbol
       def find_existing_openid_registration_method(value = nil)
-#        rw_config(:find_by_openid_identifier_method, value, :find_by_openid_identifier)
         rw_config(:find_existing_openid_registration_method, value, :find_existing_openid_registration)
       end
-#      alias_method :find_by_openid_identifier_method=, :find_by_openid_identifier_method
-      alias_method :find_existing_openid_registration_method=, :find_existing_openid_registration_method
 
+      alias_method :find_existing_openid_registration_method=, :find_existing_openid_registration_method
 
       # Add this in your Session object to Auto Register a new user using openid via sreg
       def auto_register(value=true)
@@ -38,12 +36,12 @@ module AuthlogicOpenid
       end
 
       def auto_register_value(value=nil)
-        rw_config(:auto_register,value,false)
+        rw_config(:auto_register, value, false)
       end
 
-      alias_method :auto_register=,:auto_register
+      alias_method :auto_register=, :auto_register
     end
-    
+
     module Methods
       def self.included(klass)
         klass.class_eval do
@@ -52,7 +50,7 @@ module AuthlogicOpenid
           validate :validate_by_openid, :if => :authenticating_with_openid?
         end
       end
-      
+
       # Hooks into credentials so that you can pass an :openid_identifier key.
       def credentials=(value)
         super
@@ -60,7 +58,7 @@ module AuthlogicOpenid
         hash = values.first.is_a?(Hash) ? values.first.with_indifferent_access : nil
         self.openid_identifier = hash[:openid_identifier] if !hash.nil? && hash.key?(:openid_identifier)
       end
-      
+
       def openid_identifier=(value)
         @openid_identifier = value.blank? ? nil : OpenID.normalize_url(value)
         @openid_error = nil
@@ -68,69 +66,69 @@ module AuthlogicOpenid
         @openid_identifier = nil
         @openid_error = e.message
       end
-      
+
       # Clears out the block if we are authenticating with OpenID, so that we can redirect without a DoubleRender
       # error.
       def save(&block)
         block = nil if !openid_identifier.blank? && controller.request.env[Rack::OpenID::RESPONSE].blank?
         super(&block)
       end
-      
+
       private
-        def authenticating_with_openid?
-          attempted_record.nil? && errors.empty? && (!openid_identifier.blank? || (controller.using_open_id? && controller.params[:for_session]))
-        end
-        
-        def find_existing_openid_registration_method
-          self.class.find_existing_openid_registration_method
-        end
+      def authenticating_with_openid?
+        attempted_record.nil? && errors.empty? && (!openid_identifier.blank? || (controller.using_open_id? && controller.params[:for_session]))
+      end
 
-        def auto_register?
-          self.class.auto_register_value
-        end
+      def find_existing_openid_registration_method
+        self.class.find_existing_openid_registration_method
+      end
 
-        def validate_by_openid
-          self.remember_me = controller.params[:remember_me] == "true" if controller.params.key?(:remember_me)
-          
-          options = {
-           :required => klass.openid_required_fields,
-           :optional => klass.openid_optional_fields,
-           :return_to => controller.url_for(:for_session => "1", :remember_me => remember_me?),
-           :method => :post}
+      def auto_register?
+        self.class.auto_register_value
+      end
 
-          controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, sreg_response, ax_response|
-            if result.unsuccessful?
-              errors.add_to_base(result.message)
-              return
-            end
-            
-            self.attempted_record = klass.send(find_existing_openid_registration_method, openid_identifier, sreg_response, ax_response)
-            
-            if !attempted_record
-              if auto_register?
-                auto_reg_record = create_open_id_auto_register_record(openid_identifier, sreg_response, ax_response)
-                if !auto_reg_record.save_without_session_maintenance
-                  auto_reg_record.errors.each {|attr, msg| errors.add(attr, msg) }
-                else
-                  self.attempted_record = auto_reg_record
-                end
+      def validate_by_openid
+        self.remember_me = controller.params[:remember_me] == "true" if controller.params.key?(:remember_me)
+
+        options = {
+            :required => klass.openid_required_fields,
+            :optional => klass.openid_optional_fields,
+            :return_to => controller.url_for(:for_session => "1", :remember_me => remember_me?),
+            :method => :post}
+
+        controller.send(:authenticate_with_open_id, openid_identifier, options) do |result, openid_identifier, sreg_response, ax_response|
+          if result.unsuccessful?
+            errors.add_to_base(result.message)
+            return
+          end
+
+          self.attempted_record = klass.send(find_existing_openid_registration_method, openid_identifier, sreg_response, ax_response)
+
+          if !attempted_record
+            if auto_register?
+              auto_reg_record = create_open_id_auto_register_record(openid_identifier, sreg_response, ax_response)
+              if !auto_reg_record.save_without_session_maintenance
+                auto_reg_record.errors.each { |attr, msg| errors.add(attr, msg) }
               else
-                errors.add(:openid_identifier, "did not match any users in our database, have you set up your account to use OpenID?")
+                self.attempted_record = auto_reg_record
               end
+            else
+              errors.add(:openid_identifier, "did not match any users in our database, have you set up your account to use OpenID?")
             end
           end
         end
+      end
 
-        def create_open_id_auto_register_record(openid_identifier, sreg_response, ax_response)
-          returning klass.new do |auto_reg_record|
-            auto_reg_record.openid_identifier = openid_identifier
-            auto_reg_record.send(:map_openid_registration, sreg_response, ax_response)
-          end
+      def create_open_id_auto_register_record(openid_identifier, sreg_response, ax_response)
+        returning klass.new do |auto_reg_record|
+          auto_reg_record.openid_identifier = openid_identifier
+          auto_reg_record.send(:map_openid_registration, sreg_response, ax_response)
         end
-        
-        def validate_openid_error
-          errors.add(:openid_identifier, @openid_error) if @openid_error
-        end
+      end
+
+      def validate_openid_error
+        errors.add(:openid_identifier, @openid_error) if @openid_error
+      end
     end
   end
 end

--- a/lib/authlogic_openid/version.rb
+++ b/lib/authlogic_openid/version.rb
@@ -41,7 +41,7 @@ module AuthlogicOpenid
 
     MAJOR = 1
     MINOR = 0
-    TINY  = 4
+    TINY  = 5
 
     # The current version as a Version instance
     CURRENT = new(MAJOR, MINOR, TINY)


### PR DESCRIPTION
The project https://github.com/Velir/open_id_authentication made a change that passes the AX Response in addition to the SReg Response to blocks. This pull requests adds the ax_response parameter to block calls and passes it on to the map_openid_registration method so that models can now interact with the AX Response.
